### PR TITLE
Fix error in solidus calc when CO2=37 wt %

### DIFF
--- a/vbr/vbrCore/functions/thermal_properties/SoLiquidus.m
+++ b/vbr/vbrCore/functions/thermal_properties/SoLiquidus.m
@@ -182,7 +182,7 @@ function [dTz] = depression_dasgupta(CO2_z)
      CO2 = CO2_z(iz);
      if CO2 <= 25
          dT = 27.04 * CO2 +  1490.75 * log((100-1.18 * CO2)/100);
-     elseif CO2 > 25 && CO2 < 37;
+     elseif CO2 > 25 && CO2 <= 37
          dTmax = 27.04 * 25 +  1490.75 * log((100-1.18 * 25)/100);
          dT = dTmax +  (160 - dTmax)/(37 - 25) * (CO2-25);
      elseif CO2 > 37


### PR DESCRIPTION
Small fix to the solidus depression calculation of Dasgupta et al (2007), which causes an error when CO2 is exactly 37 wt%.