### PR TITLE
allow user-specified unrelaxed shear and bulk moduli

### DIFF
--- a/vbr/testing/test_vbrcore_007_G_K_TP.m
+++ b/vbr/testing/test_vbrcore_007_G_K_TP.m
@@ -1,0 +1,65 @@
+function TestResult = test_vbrcore_007_G_K_TP()
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+% TestResult = test_vbrcore_007_G_K_TP()
+%
+% test that we can supply G_TP and K_TP
+%
+% Parameters
+% ----------
+% none
+%
+% Output
+% ------
+% TestResult   True if passed, False otherwise.
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+  TestResult=true;
+  disp('    **** Running test_vbrcore_007_G_K_TP ****')
+
+  % arbitrary values here, just making sure we execute correctly
+  VBR = get_init_VBR();
+  VBR.in.elastic.Gu_TP = linspace(50, 60, 4) * 1e9;
+  VBR.in.elastic.Ku_TP = VBR.in.elastic.Gu_TP * 1.5;
+  VBR = VBR_spine(VBR);
+
+  Gu = VBR.out.elastic.anharmonic.Gu;
+  if sum(Gu == VBR.in.elastic.Gu_TP) ~= 4
+    disp('anharmonic.Gu does not match input G_TP')
+    TestResult = false;
+  end
+
+  Ku = VBR.out.elastic.anharmonic.Ku;
+  if sum(Ku == VBR.in.elastic.Ku_TP) ~= 4
+    disp('anharmonic.Ku does not match input K_TP')
+    TestResult = false;
+  end
+
+  % also check that only supplying G_TP works
+  VBR = get_init_VBR();
+  VBR.in.elastic.Gu_TP = linspace(50, 60, 4) * 1e9;
+  VBR = VBR_spine(VBR);
+
+  Gu = VBR.out.elastic.anharmonic.Gu;
+  if sum(Gu == VBR.in.elastic.Gu_TP) ~= 4
+    disp('anharmonic.Gu does not match input G_TP (only G_TP supplied)')
+    TestResult = false;
+  end
+
+end
+
+
+function VBR = get_init_VBR()
+  VBR = struct();
+  VBR.in.SV.T_K = linspace(800, 1000, 4);
+  sz_T = size(VBR.in.SV.T_K);
+  VBR.in.SV.P_GPa = linspace(2, 3, 4);
+  VBR.in.SV.rho = 3300 * ones(sz_T);
+  VBR.in.SV.phi = 0.01 * ones(sz_T);
+  VBR.in.SV.sig_MPa = 1 * ones(sz_T);
+  VBR.in.SV.dg_um = 1e4 * ones(sz_T);
+  VBR.in.SV.f = [0.01, 0.1];
+
+  VBR.in.elastic.methods_list={'anharmonic';'anh_poro';};
+  VBR.in.anelastic.methods_list={'eburgers_psp';'andrade_psp';'xfit_mxw'};
+  VBR.in.viscous.methods_list={'HZK2011'};
+end

--- a/vbr/vbrCore/functions/el_ModUnrlx_dTdP_f.m
+++ b/vbr/vbrCore/functions/el_ModUnrlx_dTdP_f.m
@@ -28,11 +28,25 @@ function [ VBR ] = el_ModUnrlx_dTdP_f( VBR )
   dT = (VBR.in.SV.T_K-T_K_ref);
   dP = (VBR.in.SV.P_GPa*1e9 - P_Pa_ref);
 
-  % calculate shear modulus at T,P of interest
-  Gu_TP = calc_Gu(Gu_0,dT,dP,dG_dT0,dG_dP0);
+  if isfield(VBR.in.elastic,'Gu_TP') && isfield(VBR.in.elastic,'Ku_TP')
+    % Load unrelaxed shear and bulk moduli (at T,P of interest)
+    Gu_TP = VBR.in.elastic.Gu_TP; % Pa
+    Ku_TP = VBR.in.elastic.Ku_TP; % Pa
+    
+  elseif isfield(VBR.in.elastic,'Gu_TP') && ~isfield(VBR.in.elastic,'Ku_TP')
+    % Load unrelaxed shear modulus (at T,P of interest)
+    Gu_TP = VBR.in.elastic.Gu_TP; % Pa
+    
+    % calculate bulk modulus
+    warning(['No Bulk Modulus found. Calculating assuming nu=',num2str(nu)]);
+    Ku_TP = calc_Ku(Gu_TP,nu);
+  else
+    % calculate shear modulus at T,P of interest
+    Gu_TP = calc_Gu(Gu_0,dT,dP,dG_dT0,dG_dP0);
 
-  % calculate bulk modulus
-  Ku_TP = calc_Ku(Gu_TP,nu);
+    % calculate bulk modulus
+    Ku_TP = calc_Ku(Gu_TP,nu);
+  end
 
   % calculate velocities
   [Vp,Vs] = el_VpVs_unrelaxed(Ku_TP,Gu_TP,VBR.in.SV.rho);

--- a/vbr/vbrCore/functions/el_ModUnrlx_dTdP_f.m
+++ b/vbr/vbrCore/functions/el_ModUnrlx_dTdP_f.m
@@ -39,6 +39,8 @@ function [ VBR ] = el_ModUnrlx_dTdP_f( VBR )
     warning(['No Bulk Modulus found. Calculating assuming nu=',num2str(nu)]);
     Ku_TP = calc_Ku(Gu_TP,nu);
   else
+      dT = (VBR.in.SV.T_K-T_K_ref);
+      dP = (VBR.in.SV.P_GPa*1e9 - P_Pa_ref);
     % calculate shear modulus at T,P of interest
     Gu_TP = calc_Gu(Gu_0,dT,dP,dG_dT0,dG_dP0);
 

--- a/vbr/vbrCore/functions/el_ModUnrlx_dTdP_f.m
+++ b/vbr/vbrCore/functions/el_ModUnrlx_dTdP_f.m
@@ -25,8 +25,6 @@ function [ VBR ] = el_ModUnrlx_dTdP_f( VBR )
   T_K_ref = ela.T_K_ref ;
   P_Pa_ref = ela.P_Pa_ref ;
   Gu_0=VBR.out.elastic.Gu_0; % Pa
-  dT = (VBR.in.SV.T_K-T_K_ref);
-  dP = (VBR.in.SV.P_GPa*1e9 - P_Pa_ref);
 
   if isfield(VBR.in.elastic,'Gu_TP') && isfield(VBR.in.elastic,'Ku_TP')
     % Load unrelaxed shear and bulk moduli (at T,P of interest)

--- a/vbr/vbrCore/functions/el_ModUnrlx_dTdP_f.m
+++ b/vbr/vbrCore/functions/el_ModUnrlx_dTdP_f.m
@@ -30,6 +30,7 @@ function [ VBR ] = el_ModUnrlx_dTdP_f( VBR )
     % Load unrelaxed shear and bulk moduli (at T,P of interest)
     Gu_TP = VBR.in.elastic.Gu_TP; % Pa
     Ku_TP = VBR.in.elastic.Ku_TP; % Pa
+    VBR.out.elastic.Gu_0 = Gu_TP; 
     
   elseif isfield(VBR.in.elastic,'Gu_TP') && ~isfield(VBR.in.elastic,'Ku_TP')
     % Load unrelaxed shear modulus (at T,P of interest)

--- a/vbr/vbrCore/functions/el_ModUnrlx_dTdP_f.m
+++ b/vbr/vbrCore/functions/el_ModUnrlx_dTdP_f.m
@@ -37,7 +37,9 @@ function [ VBR ] = el_ModUnrlx_dTdP_f( VBR )
     Gu_TP = VBR.in.elastic.Gu_TP; % Pa
     
     % calculate bulk modulus
-    warning(['No Bulk Modulus found. Calculating assuming nu=',num2str(nu)]);
+disp(['Unrelaxed shear modulus was provided without an unrelaxed bulk modulus.', ...
+          ' Calculating bulk modulus assuming nu=', num2str(nu), ...
+          '. Set VBR.in.elastic.Ku_TP to specify a value.']);
     Ku_TP = calc_Ku(Gu_TP,nu);
   else
       dT = (VBR.in.SV.T_K-T_K_ref);


### PR DESCRIPTION
One can specify unrelaxed bulk and shear moduli (such as from perplex) directly. The code checks for shear and bulk modulus. If only shear modulus exists, then bulk is calculated with a warning about the assumed value of nu. If neither exist, the reference modulus is used as before.