### PR TITLE
Bayes mcmc 0d example

### DIFF
--- a/Projects/bayesian_fitting_0d_mcmc/bayes_0d_funcs/cdf_normal.m
+++ b/Projects/bayesian_fitting_0d_mcmc/bayes_0d_funcs/cdf_normal.m
@@ -1,0 +1,32 @@
+function phi = cdf_normal(x, mean_val, std_val)
+    %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+    % phi = cdf_normal(x, mean_val, std_val)
+    %
+    % Evaluate the cumulative distribution function for a
+    % normal distribution.
+    %
+    % note: this is mainly for demo purposes to avoid
+    % needing the octave statistics package of matlab
+    % statistics toolbox installed.
+    %
+    % Parameters
+    % ----------
+    % x
+    %    the value or values to calculate the CDF value for
+    % mean_val
+    %    the mean value of the normal distribution
+    % std_val
+    %    the standard deviation of the normal distribution
+    %
+    % Returns
+    % -------
+    % CDF(x)
+    %     the value of the cumulative distribution function for a
+    %     normal disribution evaluated at x.
+    %
+    % Notes
+    % -----
+    % See https://www.johndcook.com//erf_and_normal_cdf.pdf
+    %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+    phi = .5 * (1 + erf( (x - mean_val) / (sqrt(2) * std_val)));
+end

--- a/Projects/bayesian_fitting_0d_mcmc/bayes_0d_funcs/check_normal_sampling.m
+++ b/Projects/bayesian_fitting_0d_mcmc/bayes_0d_funcs/check_normal_sampling.m
@@ -1,0 +1,46 @@
+% visual check that the inv_cdf_normal function works as expected.
+% compares to the normrnd function from octave statistics package
+% so this script requires that package. (`pkg install statistics`)
+%
+% also uses the probability_distributions function in vbr, so
+% vbr is initialized here
+
+addpath('../../../')
+vbr_init % to use probability_distributions
+pkg load 'statistics'
+
+n = [1000,1];
+mean_val = 50;
+std_val = 5;
+u = rand(n);
+samples = inv_cdf_normal(u, mean_val, std_val);
+samples_2 = normrnd (mean_val, std_val, n);
+
+x = linspace(0,100,200);
+% get the pdf using vbrc function
+p_x = probability_distributions('normal', x, mean_val, std_val);
+% also get the pdf using statistics package
+p_x_2 =normpdf(x, mean_val, std_val);
+
+% do it once to get bin width
+n_bins = 20;
+[binned_vals, bin_centers] = hist(samples, n_bins, 1);
+bin_wid = mean(diff(bin_centers));
+
+subplot(1,2,1)
+hold off
+hist(samples, n_bins, 1 ./ bin_wid);
+hold on
+plot(x,p_x,'b','linewidth',2)
+plot(x,p_x_2,'--r','linewidth',2)
+title(mean(samples))
+set(gca,'ylim',[0,.1])
+
+subplot(1,2,2)
+hold off
+hist(samples_2, n_bins, 1 ./ bin_wid)
+hold on
+plot(x,p_x,'b','linewidth',2)
+plot(x,p_x_2,'--r','linewidth',2)
+title(mean(samples_2))
+set(gca,'ylim',[0,.1])

--- a/Projects/bayesian_fitting_0d_mcmc/bayes_0d_funcs/draw_temperature.m
+++ b/Projects/bayesian_fitting_0d_mcmc/bayes_0d_funcs/draw_temperature.m
@@ -1,0 +1,9 @@
+function [T_K] = draw_temperature(n,T_K_mean, T_K_std)
+
+    % random sample from normal distrubiton
+    T_K = sample_normal(n, T_K_mean, T_K_std);
+
+    % if statistics package (octave) or statistics toolbox (matlab)
+    % were installed, could do:
+    % T_K_= normrnd(T_K_mean, T_K_std, n);
+end

--- a/Projects/bayesian_fitting_0d_mcmc/bayes_0d_funcs/draw_temperature.m
+++ b/Projects/bayesian_fitting_0d_mcmc/bayes_0d_funcs/draw_temperature.m
@@ -2,6 +2,7 @@ function [T_K] = draw_temperature(n,T_K_mean, T_K_std)
 
     % random sample from normal distrubiton
     T_K = sample_normal(n, T_K_mean, T_K_std);
+    T_K(T_K < 10) = 10;
 
     % if statistics package (octave) or statistics toolbox (matlab)
     % were installed, could do:

--- a/Projects/bayesian_fitting_0d_mcmc/bayes_0d_funcs/get_data.m
+++ b/Projects/bayesian_fitting_0d_mcmc/bayes_0d_funcs/get_data.m
@@ -1,0 +1,46 @@
+function [input_data] = get_data()
+
+    VBR = struct();
+    VBR.in.elastic.methods_list={'anharmonic';};
+    VBR.in.viscous.methods_list={'HK2003'};
+    VBR.in.anelastic.methods_list={'eburgers_psp';};
+
+    % state variables: get a range of T values about a mean
+    % with std of 25
+    T_K = randn(1000,1) * 25 + 1473;
+    VBR.in.SV.T_K = T_K; % temperature [K]
+
+    n1 = size(T_K);
+    VBR.in.SV.P_GPa = full_nd(2, n1);
+    rho = san_carlos_density_from_pressure(VBR.in.SV.P_GPa);
+    rho = Density_Thermal_Expansion(rho, VBR.in.SV.T_K, 0.9);
+    VBR.in.SV.rho = rho; % density [kg m^-3]
+    VBR.in.SV.sig_MPa = full_nd(0.1, n1); % differential stress [MPa]
+    VBR.in.SV.phi = full_nd(0, n1); % melt fraction
+    VBR.in.SV.dg_um = full_nd(0.01 * 1e6, n1); % grain size [um]
+    VBR.in.SV.f = 1 / 50.; % frequency [Hz]
+
+
+    VBR = VBR_spine(VBR);
+    input_data.VBR = VBR;
+
+    % store the mean and std of T_K, and the result
+    Vs = VBR.out.anelastic.eburgers_psp.V;
+    Q = VBR.out.anelastic.eburgers_psp.Q;
+    input_data.Vs_mean = mean(Vs);
+    input_data.Vs_std = std(Vs);
+    input_data.Q_std = std(Q);
+    input_data.Q_mean = mean(Q);
+    input_data.T_mean = mean(T_K);
+    input_data.T_std = std(T_K);
+
+    fixed_values.P_GPa = VBR.in.SV.P_GPa(1);
+    fixed_values.sig_MPa = VBR.in.SV.sig_MPa(1);
+    fixed_values.phi = VBR.in.SV.phi(1);
+    fixed_values.dg_um = VBR.in.SV.dg_um(1);
+    fixed_values.f = VBR.in.SV.f(1);
+    fixed_values.rho = VBR.in.SV.rho(1);
+    fixed_values.T_K_mean = 1473;
+    fixed_values.T_K_std = 25;
+    input_data.fixed_values = fixed_values;
+end

--- a/Projects/bayesian_fitting_0d_mcmc/bayes_0d_funcs/get_data.m
+++ b/Projects/bayesian_fitting_0d_mcmc/bayes_0d_funcs/get_data.m
@@ -1,16 +1,31 @@
 function [input_data] = get_data(settings)
 
-    % get a range of T values about a mean with std of 25
-    current_model.T_K = randn(1000,1) * 25 + 1673;
-    current_model = update_model_predictions(current_model, settings);
+    if settings.fit_a_fixed_TK == 1
+        % set exact T, calculate Vs, Q and set arbitary standard deviations
+        current_model.T_K = 1673;
+        current_model = update_model_predictions(current_model, settings);
 
+        input_data.VBR = current_model.VBR;
+        input_data.Vs_mean = mean(current_model.Vs);
+        input_data.Q_mean = mean(current_model.Q);
+        input_data.T_mean = mean(current_model.T_K);
+        % arbitrary standard deviations
+        input_data.Vs_std = 15;
+        input_data.Q_std = 6;
+        input_data.T_std = 25;
+    else
+        % get a range of T values about a mean with std of 25
+        current_model.T_K = randn(1000,1) * 25 + 1673;
+        current_model = update_model_predictions(current_model, settings);
 
-    % store the mean and std of T_K, and the result
-    input_data.VBR = current_model.VBR;
-    input_data.Vs_mean = mean(current_model.Vs);
-    input_data.Vs_std = std(current_model.Vs);
-    input_data.Q_std = std(current_model.Q);
-    input_data.Q_mean = mean(current_model.Q);
-    input_data.T_mean = mean(current_model.T_K);
-    input_data.T_std = std(current_model.T_K);
+        % store the mean and std of T_K, and the result
+        input_data.VBR = current_model.VBR;
+        input_data.Vs_mean = mean(current_model.Vs);
+        input_data.Vs_std = std(current_model.Vs);
+        input_data.Q_std = std(current_model.Q);
+        input_data.Q_mean = mean(current_model.Q);
+        input_data.T_mean = mean(current_model.T_K);
+        input_data.T_std = std(current_model.T_K);
+    end
+
 end

--- a/Projects/bayesian_fitting_0d_mcmc/bayes_0d_funcs/get_data.m
+++ b/Projects/bayesian_fitting_0d_mcmc/bayes_0d_funcs/get_data.m
@@ -1,46 +1,16 @@
-function [input_data] = get_data()
+function [input_data] = get_data(settings)
 
-    VBR = struct();
-    VBR.in.elastic.methods_list={'anharmonic';};
-    VBR.in.viscous.methods_list={'HK2003'};
-    VBR.in.anelastic.methods_list={'eburgers_psp';};
+    % get a range of T values about a mean with std of 25
+    current_model.T_K = randn(1000,1) * 25 + 1673;
+    current_model = update_model_predictions(current_model, settings);
 
-    % state variables: get a range of T values about a mean
-    % with std of 25
-    T_K = randn(1000,1) * 25 + 1473;
-    VBR.in.SV.T_K = T_K; % temperature [K]
-
-    n1 = size(T_K);
-    VBR.in.SV.P_GPa = full_nd(2, n1);
-    rho = san_carlos_density_from_pressure(VBR.in.SV.P_GPa);
-    rho = Density_Thermal_Expansion(rho, VBR.in.SV.T_K, 0.9);
-    VBR.in.SV.rho = rho; % density [kg m^-3]
-    VBR.in.SV.sig_MPa = full_nd(0.1, n1); % differential stress [MPa]
-    VBR.in.SV.phi = full_nd(0, n1); % melt fraction
-    VBR.in.SV.dg_um = full_nd(0.01 * 1e6, n1); % grain size [um]
-    VBR.in.SV.f = 1 / 50.; % frequency [Hz]
-
-
-    VBR = VBR_spine(VBR);
-    input_data.VBR = VBR;
 
     % store the mean and std of T_K, and the result
-    Vs = VBR.out.anelastic.eburgers_psp.V;
-    Q = VBR.out.anelastic.eburgers_psp.Q;
-    input_data.Vs_mean = mean(Vs);
-    input_data.Vs_std = std(Vs);
-    input_data.Q_std = std(Q);
-    input_data.Q_mean = mean(Q);
-    input_data.T_mean = mean(T_K);
-    input_data.T_std = std(T_K);
-
-    fixed_values.P_GPa = VBR.in.SV.P_GPa(1);
-    fixed_values.sig_MPa = VBR.in.SV.sig_MPa(1);
-    fixed_values.phi = VBR.in.SV.phi(1);
-    fixed_values.dg_um = VBR.in.SV.dg_um(1);
-    fixed_values.f = VBR.in.SV.f(1);
-    fixed_values.rho = VBR.in.SV.rho(1);
-    fixed_values.T_K_mean = 1473;
-    fixed_values.T_K_std = 25;
-    input_data.fixed_values = fixed_values;
+    input_data.VBR = current_model.VBR;
+    input_data.Vs_mean = mean(current_model.Vs);
+    input_data.Vs_std = std(current_model.Vs);
+    input_data.Q_std = std(current_model.Q);
+    input_data.Q_mean = mean(current_model.Q);
+    input_data.T_mean = mean(current_model.T_K);
+    input_data.T_std = std(current_model.T_K);
 end

--- a/Projects/bayesian_fitting_0d_mcmc/bayes_0d_funcs/inv_cdf_normal.m
+++ b/Projects/bayesian_fitting_0d_mcmc/bayes_0d_funcs/inv_cdf_normal.m
@@ -1,0 +1,37 @@
+function phiinv = inv_cdf_normal(x, mean_val, std_val)
+    %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+    % phiinv = inv_cdf_normal(x, mean_val, std_val)
+    %
+    % Evaluate the inverse cumulative distribution function for a
+    % normal distribution.
+    %
+    % note: this is mainly for demo purposes to avoid
+    % needing the octave statistics package of matlab
+    % statistics toolbox installed.
+    %
+    % Parameters
+    % ----------
+    % x
+    %    the value or values to calculate the CDF value for
+    % mean_val
+    %    the mean value of the normal distribution
+    % std_val
+    %    the standard deviation of the normal distribution
+    %
+    % Returns
+    % -------
+    % inverseCDF(x)
+    %     the value of the inverse cumulative distribution function
+    %     for a normal disribution evaluated at x.
+    %
+    % Notes
+    % -----
+    % See https://www.johndcook.com//erf_and_normal_cdf.pdf
+    %
+    % To sample from a normal distribution:
+    %;
+    %
+    %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+    phiinv = sqrt(2) * std_val * erfinv(2*x -1) + mean_val;
+
+end

--- a/Projects/bayesian_fitting_0d_mcmc/bayes_0d_funcs/sample_normal.m
+++ b/Projects/bayesian_fitting_0d_mcmc/bayes_0d_funcs/sample_normal.m
@@ -1,0 +1,5 @@
+function samples = sample_normal(n, mean_val, std_val)
+    % random sample from normal distrubiton
+    u = rand(n);
+    samples = inv_cdf_normal(u, mean_val, std_val);
+end

--- a/Projects/bayesian_fitting_0d_mcmc/bayes_0d_funcs/update_likelihood.m
+++ b/Projects/bayesian_fitting_0d_mcmc/bayes_0d_funcs/update_likelihood.m
@@ -1,0 +1,21 @@
+function current_model = update_likelihood(current_model, input_data)
+
+    Vs_predicted = current_model.Vs;
+    Q_predicted = current_model.Q;
+    p_Vs_T = probability_distributions('likelihood from residuals', ...
+                                       input_data.Vs_mean,
+                                       input_data.Vs_std,
+                                       Vs_predicted);
+
+    p_Q_T = probability_distributions('likelihood from residuals', ...
+                                       input_data.Q_mean,
+                                       input_data.Q_std,
+                                       Q_predicted);
+
+    p_VsQ_T = p_Vs_T .* p_Q_T;
+
+    current_model.p_Q_T = p_Q_T;
+    current_model.p_Vs_T = p_Vs_T;
+    current_model.p_VsQ_T = p_VsQ_T;
+
+end

--- a/Projects/bayesian_fitting_0d_mcmc/bayes_0d_funcs/update_model_predictions.m
+++ b/Projects/bayesian_fitting_0d_mcmc/bayes_0d_funcs/update_model_predictions.m
@@ -1,0 +1,25 @@
+function current_model = update_model_predictions(current_model, settings)
+    VBR = struct();
+    VBR.in.elastic.methods_list={'anharmonic';};
+    VBR.in.viscous.methods_list={'HK2003'};
+    VBR.in.anelastic.methods_list={settings.anelastic_method;};
+
+    T_K = current_model.T_K;
+    VBR.in.SV.T_K = T_K; % temperature [K]
+
+    n1 = size(T_K);
+    VBR.in.SV.P_GPa = full_nd(settings.fixed_SVs.P_GPa, n1);
+    rho = san_carlos_density_from_pressure(VBR.in.SV.P_GPa);
+    rho = Density_Thermal_Expansion(rho, VBR.in.SV.T_K, 0.9);
+    VBR.in.SV.rho = rho; % density [kg m^-3]
+    VBR.in.SV.sig_MPa = full_nd(settings.fixed_SVs.sig_MPa, n1); % differential stress [MPa]
+    VBR.in.SV.phi = full_nd(settings.fixed_SVs.phi, n1); % melt fraction
+    VBR.in.SV.dg_um = full_nd(settings.fixed_SVs.dg_um, n1); % grain size [um]
+    VBR.in.SV.f = settings.fixed_SVs.f; % frequency [Hz]
+
+    VBR = VBR_spine(VBR);
+
+    current_model.VBR = VBR;
+    current_model.Vs = VBR.out.anelastic.(settings.anelastic_method).V;
+    current_model.Q = VBR.out.anelastic.(settings.anelastic_method).Q;
+end

--- a/Projects/bayesian_fitting_0d_mcmc/bayes_0d_funcs/update_posterior.m
+++ b/Projects/bayesian_fitting_0d_mcmc/bayes_0d_funcs/update_posterior.m
@@ -1,0 +1,3 @@
+function current_model = update_posterior(current_model);
+    current_model.p_T_Vs_Q = current_model.p_T .* current_model.p_VsQ_T;
+end

--- a/Projects/bayesian_fitting_0d_mcmc/bayes_0d_funcs/update_prior_probability.m
+++ b/Projects/bayesian_fitting_0d_mcmc/bayes_0d_funcs/update_prior_probability.m
@@ -1,0 +1,8 @@
+function current_model = update_prior_probability(current_model, priors)
+
+    mean_val = priors.T_K_mean;
+    std_val = priors.T_K_std;
+    T_K = current_model.T_K;
+    p_T = probability_distributions('normal', T_K, mean_val, std_val);
+    current_model.p_T = p_T;
+end

--- a/Projects/bayesian_fitting_0d_mcmc/bayes_0d_mcmc_Tonly.m
+++ b/Projects/bayesian_fitting_0d_mcmc/bayes_0d_mcmc_Tonly.m
@@ -11,9 +11,9 @@ priors.T_K_std = 200;  % standard deviation of T_K prior distribution
 % mcmc settings:
 % for testing, the following are set to small numbers. they should be increased,
 % which will be obvious when you run this with small numbers...
-settings.max_mcmc_iters = 100; % max iterations for this chain
+settings.mcmc_max_iters = 100; % max iterations for this chain
 settings.mcmc_info_very_N = 10; % print info every N steps
-settings.mcmc_burnin_iters = round(0.2 * settings.max_mcmc_iters); % burn in iterations
+settings.mcmc_burnin_iters = round(0.2 * settings.mcmc_max_iters); % burn in iterations
 settings.mcmc_jump_std = priors.T_K_std * .05; % the jump magnitude for updating T_K
 settings.mcmc_initial_T_K = 0; % set to 0 to draw initial guess from distribution
 settings.mcmc_initial_guess_jump_std = priors.T_K_std; % jump magnitude for the initial guess
@@ -57,7 +57,7 @@ disp(["   Vs = ", num2str(current_model.Vs)])
 disp(["   Q = ", num2str(current_model.Q)])
 
 % start the itreations
-results.mcmc_samples_T_K = zeros(settings.max_mcmc_iters,1);
+results.mcmc_samples_T_K = zeros(settings.mcmc_max_iters,1);
 mcmc_sample_i = 1;
 current_iter = 1;
 
@@ -65,7 +65,7 @@ disp("")
 disp("Starting chain iterations")
 disp("")
 
-while current_iter <= settings.max_mcmc_iters
+while current_iter <= settings.mcmc_max_iters
 
     if rem(current_iter, settings.mcmc_info_very_N) == 0
         if current_iter >= settings.mcmc_burnin_iters + 1

--- a/Projects/bayesian_fitting_0d_mcmc/bayes_0d_mcmc_Tonly.m
+++ b/Projects/bayesian_fitting_0d_mcmc/bayes_0d_mcmc_Tonly.m
@@ -135,23 +135,15 @@ plot(results.mcmc_samples_T_K)  % full
 hold all
 % plot only the iterations after the burn in
 plot(results.after_iters, results.after_burn)
-% add a line for the actual input T
-plot([1, results.mcmc_sample_i],[input_data.T_mean, input_data.T_mean],'--k')
 xlabel("iterations")
 ylabel("T_K")
 
 subplot(1,2,2)
 hist(results.after_burn)
 results.mean_T_K = mean(results.after_burn);
-results.final_error = abs(results.mean_T_K - input_data.T_mean)./input_data.T_mean;
-ttl_str = ["mean T_K = ", num2str(mean(results.after_burn)), ...
-           " , error = ", num2str(results.final_error)];
+ttl_str = ["mean T_K = ", num2str(mean(results.after_burn))];
 title(ttl_str)
 
 disp('')
 disp('final mean:')
 disp(['   T_K = ', num2str(results.mean_T_K)])
-disp('actual:')
-disp(['   T_K_input = ', num2str(input_data.T_mean)])
-disp('relative error:')
-disp(['   abs(T_K_input-T_K) / T_K_input = ', num2str(results.final_error)])

--- a/Projects/bayesian_fitting_0d_mcmc/bayes_0d_mcmc_Tonly.m
+++ b/Projects/bayesian_fitting_0d_mcmc/bayes_0d_mcmc_Tonly.m
@@ -1,0 +1,14 @@
+%% put VBR in the path %%
+clear
+path_to_top_level_vbr='../../';
+addpath(path_to_top_level_vbr)
+addpath('bayes_0d_funcs')
+vbr_init
+
+input_data = get_data();  % the synthetic data we want to fit
+
+disp("Synthetic observations to fit are:")
+disp(['Vs = ', num2str(input_data.Vs_mean), ' with stand. dev. ' num2str(input_data.Vs_std)])
+disp(['Q = ', num2str(input_data.Q_mean), ' with stand. dev. ' num2str(input_data.Q_std)])
+
+

--- a/Projects/bayesian_fitting_0d_mcmc/bayes_0d_mcmc_Tonly.m
+++ b/Projects/bayesian_fitting_0d_mcmc/bayes_0d_mcmc_Tonly.m
@@ -4,24 +4,39 @@ addpath(path_to_top_level_vbr)
 addpath('bayes_0d_funcs')
 vbr_init
 
+% prior distribution settings
+priors.T_K_mean = 1200 + 273;  % mean of T_K prior distribution
+priors.T_K_std = 200;  % standard deviation of T_K prior distribution
+
+% mcmc settings:
+% for testing, the following are set to small numbers. they should be increased,
+% which will be obvious when you run this with small numbers...
+settings.max_mcmc_iters = 100; % max iterations for this chain
+settings.mcmc_info_very_N = 10; % print info every N steps
+settings.mcmc_burnin_iters = round(0.2 * settings.max_mcmc_iters); % burn in iterations
+settings.mcmc_jump_std = priors.T_K_std * .05; % the jump magnitude for updating T_K
+settings.mcmc_initial_T_K = 0; % set to 0 to draw initial guess from distribution
+settings.mcmc_initial_guess_jump_std = priors.T_K_std; % jump magnitude for the initial guess
+settings.mcmc_acceptance_sc = 1; % acceptance threshold = sc * rand()
+
+% set the fixed state variables and single anelastic method
 settings.fixed_SVs.P_GPa = 2;
 settings.fixed_SVs.sig_MPa = 0.1;
 settings.fixed_SVs.phi = 0;
 settings.fixed_SVs.dg_um = 0.01 * 1e6;
 settings.fixed_SVs.f = 1. / 50.;
+settings.fit_a_fixed_TK = 1; % 1 to fixed hidden T_K, 0 to draw from distribution about a hidden mean
 settings.anelastic_method = 'eburgers_psp';
 
-max_mcmc_iters = 1000;
-mcmc_burnin_iters = round(0.2 * max_mcmc_iters);
-
-priors.T_K_mean = 1200 + 273;
-priors.T_K_std = 200;
-mcmc_jump_std = priors.T_K_std * .05;
-
-input_data = get_data(settings);  % the synthetic data we want to fit
+% get the synthetic data we want to fit
+input_data = get_data(settings);  % includes a hidden T_K value ...
 
 % make an initial draw for the modeled temperature, calculate
-current_model.T_K = draw_temperature(1, priors.T_K_mean, priors.T_K_std*2);
+if settings.mcmc_initial_T_K == 0
+    current_model.T_K = draw_temperature(1, priors.T_K_mean, settings.mcmc_initial_guess_jump_std);
+else
+    current_model.T_K = settings.mcmc_initial_T_K;
+end
 current_model = update_model_predictions(current_model, settings);
 current_model = update_likelihood(current_model, input_data);
 current_model = update_prior_probability(current_model, priors);
@@ -41,31 +56,49 @@ disp("  with predictions:")
 disp(["   Vs = ", num2str(current_model.Vs)])
 disp(["   Q = ", num2str(current_model.Q)])
 
-
-mcmc_samples_T_K = zeros(max_mcmc_iters,1);
+% start the itreations
+results.mcmc_samples_T_K = zeros(settings.max_mcmc_iters,1);
 mcmc_sample_i = 1;
 current_iter = 1;
-while current_iter <= max_mcmc_iters
 
-    if rem(current_iter, 100) == 0
-        disp(["mcmc step ", num2str(current_iter)])
-        disp(current_model.T_K)
+disp("")
+disp("Starting chain iterations")
+disp("")
+
+while current_iter <= settings.max_mcmc_iters
+
+    if rem(current_iter, settings.mcmc_info_very_N) == 0
+        if current_iter >= settings.mcmc_burnin_iters + 1
+            mean_T = mean(results.mcmc_samples_T_K(settings.mcmc_burnin_iters:current_iter));
+            msg = ["    mcmc step ", num2str(current_iter), ...
+                   ", model T_K=", num2str(current_model.T_K), ...
+                   "  mean T_K (after burn-in) = ", num2str(mean_T)];
+        else
+            msg = ["    mcmc step ", num2str(current_iter), ...
+                   ", model T_K=", num2str(current_model.T_K)];
+        end
+        disp(msg)
+
     end
-    % get a new model near the old by sampling from normal distribution near
+    % mcmc step 1: get a new model near the old by sampling from normal distribution near
     % current T_K guess
-    new_model.T_K = draw_temperature(1, current_model.T_K, mcmc_jump_std);
+    new_model.T_K = draw_temperature(1, current_model.T_K, settings.mcmc_jump_std);
 
-    % update stats of new model
+    % mcmc step 2: update model predictions, update the likelihood, prior and posterior
     new_model = update_model_predictions(new_model, settings);
     new_model = update_likelihood(new_model, input_data);
     new_model = update_prior_probability(new_model, priors);
     new_model = update_posterior(new_model);
 
-    % check model acceptence
-    accept_threshold = rand();
+    % check model acceptance
+    accept_threshold = settings.mcmc_acceptance_sc * rand();
 
+    % note: due to log scaling of Q, can have identically 0 probabilities for
+    % some values. could improve this by computing probabilities in log space,
+    % but we can just check for those special cases.
     if current_model.p_T_Vs_Q > 0 && new_model.p_T_Vs_Q > 0
-        accept_criteria = new_model.p_VsQ_T / (current_model.p_VsQ_T);
+        % the standard metropolis-hastings criteria
+        accept_criteria = new_model.p_VsQ_T / current_model.p_VsQ_T;
     elseif current_model.p_T_Vs_Q == 0 && new_model.p_T_Vs_Q > 0
         % take the new
         accept_criteria = 1.0;
@@ -73,43 +106,52 @@ while current_iter <= max_mcmc_iters
         % take the old
         accept_criteria = 0.0;
     else
-%        disp("both 0, yikes")
+        % both have 0 probability, flip a coin.
         accept_criteria = 0.5;
     end
 
+    % compare to the random acceptance threshold
     if accept_criteria > accept_threshold
         current_model = new_model;
     end
 
-%    if current_iter > mcmc_burnin_iters
-    mcmc_samples_T_K(mcmc_sample_i) = current_model.T_K;
+    % store current model temperature: note that this includes the burn-in
+    % iterations, which should be removed for the final analysis.
+    results.mcmc_samples_T_K(mcmc_sample_i) = current_model.T_K;
     mcmc_sample_i = mcmc_sample_i + 1;
-%    end
-
     current_iter = current_iter + 1;
 end
 
 % pull out the after_burn for analysis
-after_burn = mcmc_samples_T_K(mcmc_burnin_iters:end);
-x_after = 1:numel(after_burn);
-x_after = x_after+mcmc_burnin_iters-1 ;
+results.after_burn = results.mcmc_samples_T_K(settings.mcmc_burnin_iters:end);
+results.after_iters = 1:numel(results.after_burn);
+results.after_iters = results.after_iters+settings.mcmc_burnin_iters-1 ;
+results.mcmc_sample_i = mcmc_sample_i;
 
-
+% plot the result
 subplot(1,2,1)
-plot(mcmc_samples_T_K,'b')  % full
-hold on
-plot(x_after, after_burn, 'r') % just after burn
-plot([1, mcmc_sample_i],[input_data.T_mean, input_data.T_mean],'--k')
+% first plot the full series
+plot(results.mcmc_samples_T_K)  % full
+hold all
+% plot only the iterations after the burn in
+plot(results.after_iters, results.after_burn)
+% add a line for the actual input T
+plot([1, results.mcmc_sample_i],[input_data.T_mean, input_data.T_mean],'--k')
+xlabel("iterations")
+ylabel("T_K")
 
 subplot(1,2,2)
-hist(after_burn)
-title(mean(after_burn))
+hist(results.after_burn)
+results.mean_T_K = mean(results.after_burn);
+results.final_error = abs(results.mean_T_K - input_data.T_mean)./input_data.T_mean;
+ttl_str = ["mean T_K = ", num2str(mean(results.after_burn)), ...
+           " , error = ", num2str(results.final_error)];
+title(ttl_str)
 
+disp('')
 disp('final mean:')
-disp(['   T_K = ', num2str(mean(after_burn))])
+disp(['   T_K = ', num2str(results.mean_T_K)])
 disp('actual:')
 disp(['   T_K_input = ', num2str(input_data.T_mean)])
-
-
-
-
+disp('relative error:')
+disp(['   abs(T_K_input-T_K) / T_K_input = ', num2str(results.final_error)])

--- a/Projects/bayesian_fitting_0d_mcmc/bayes_0d_mcmc_Tonly.m
+++ b/Projects/bayesian_fitting_0d_mcmc/bayes_0d_mcmc_Tonly.m
@@ -1,14 +1,115 @@
-%% put VBR in the path %%
 clear
 path_to_top_level_vbr='../../';
 addpath(path_to_top_level_vbr)
 addpath('bayes_0d_funcs')
 vbr_init
 
-input_data = get_data();  % the synthetic data we want to fit
+settings.fixed_SVs.P_GPa = 2;
+settings.fixed_SVs.sig_MPa = 0.1;
+settings.fixed_SVs.phi = 0;
+settings.fixed_SVs.dg_um = 0.01 * 1e6;
+settings.fixed_SVs.f = 1. / 50.;
+settings.anelastic_method = 'eburgers_psp';
 
+max_mcmc_iters = 1000;
+mcmc_burnin_iters = round(0.2 * max_mcmc_iters);
+
+priors.T_K_mean = 1200 + 273;
+priors.T_K_std = 200;
+mcmc_jump_std = priors.T_K_std * .05;
+
+input_data = get_data(settings);  % the synthetic data we want to fit
+
+% make an initial draw for the modeled temperature, calculate
+current_model.T_K = draw_temperature(1, priors.T_K_mean, priors.T_K_std*2);
+current_model = update_model_predictions(current_model, settings);
+current_model = update_likelihood(current_model, input_data);
+current_model = update_prior_probability(current_model, priors);
+current_model = update_posterior(current_model);
+
+% output some info
+disp("")
 disp("Synthetic observations to fit are:")
-disp(['Vs = ', num2str(input_data.Vs_mean), ' with stand. dev. ' num2str(input_data.Vs_std)])
-disp(['Q = ', num2str(input_data.Q_mean), ' with stand. dev. ' num2str(input_data.Q_std)])
+disp(['    Vs = ', num2str(input_data.Vs_mean), ' with stand. dev. ' num2str(input_data.Vs_std)])
+disp(['    Q = ', num2str(input_data.Q_mean), ' with stand. dev. ' num2str(input_data.Q_std)])
+disp("Synthetic observations were calculated at:")
+disp(['    T = ', num2str(input_data.T_mean), ' with stand. dev. ', num2str(input_data.T_std)])
+
+disp("")
+disp(["Initial temeprature guess = ", num2str(current_model.T_K)])
+disp("  with predictions:")
+disp(["   Vs = ", num2str(current_model.Vs)])
+disp(["   Q = ", num2str(current_model.Q)])
+
+
+mcmc_samples_T_K = zeros(max_mcmc_iters,1);
+mcmc_sample_i = 1;
+current_iter = 1;
+while current_iter <= max_mcmc_iters
+
+    if rem(current_iter, 100) == 0
+        disp(["mcmc step ", num2str(current_iter)])
+        disp(current_model.T_K)
+    end
+    % get a new model near the old by sampling from normal distribution near
+    % current T_K guess
+    new_model.T_K = draw_temperature(1, current_model.T_K, mcmc_jump_std);
+
+    % update stats of new model
+    new_model = update_model_predictions(new_model, settings);
+    new_model = update_likelihood(new_model, input_data);
+    new_model = update_prior_probability(new_model, priors);
+    new_model = update_posterior(new_model);
+
+    % check model acceptence
+    accept_threshold = rand();
+
+    if current_model.p_T_Vs_Q > 0 && new_model.p_T_Vs_Q > 0
+        accept_criteria = new_model.p_VsQ_T / (current_model.p_VsQ_T);
+    elseif current_model.p_T_Vs_Q == 0 && new_model.p_T_Vs_Q > 0
+        % take the new
+        accept_criteria = 1.0;
+    elseif current_model.p_T_Vs_Q > 0
+        % take the old
+        accept_criteria = 0.0;
+    else
+%        disp("both 0, yikes")
+        accept_criteria = 0.5;
+    end
+
+    if accept_criteria > accept_threshold
+        current_model = new_model;
+    end
+
+%    if current_iter > mcmc_burnin_iters
+    mcmc_samples_T_K(mcmc_sample_i) = current_model.T_K;
+    mcmc_sample_i = mcmc_sample_i + 1;
+%    end
+
+    current_iter = current_iter + 1;
+end
+
+% pull out the after_burn for analysis
+after_burn = mcmc_samples_T_K(mcmc_burnin_iters:end);
+x_after = 1:numel(after_burn);
+x_after = x_after+mcmc_burnin_iters-1 ;
+
+
+subplot(1,2,1)
+plot(mcmc_samples_T_K,'b')  % full
+hold on
+plot(x_after, after_burn, 'r') % just after burn
+plot([1, mcmc_sample_i],[input_data.T_mean, input_data.T_mean],'--k')
+
+subplot(1,2,2)
+hist(after_burn)
+title(mean(after_burn))
+
+disp('final mean:')
+disp(['   T_K = ', num2str(mean(after_burn))])
+disp('actual:')
+disp(['   T_K_input = ', num2str(input_data.T_mean)])
+
+
 
 

--- a/Projects/bayesian_fitting_0d_mcmc/readme.md
+++ b/Projects/bayesian_fitting_0d_mcmc/readme.md
@@ -1,21 +1,62 @@
 ## `bayesian_fiting_0d_mcmc` 
 
-A single paramter bayesian marcov-chain monte carlo (mcmc) simulation with 
+A single-parameter bayesian markov-chain monte carlo (mcmc) simulation with 
 Metropolis-Hastings sampling to invert a spot measurements of shear wave velocity 
 and attenuation for the underyling temperature. 
+
+### A brief overview of MCMC + Metropolis-Hastings
+
+insert notes 
+
+### Overview of the code 
+
+```matlab
+% prior distribution settings
+priors.T_K_mean = 1200 + 273;  % mean of T_K prior distribution
+priors.T_K_std = 200;  % standard deviation of T_K prior distribution
+
+% mcmc settings:
+% for testing, the following are set to small numbers. they should be increased,
+% which will be obvious when you run this with small numbers...
+settings.max_mcmc_iters = 100; % max iterations for this chain
+settings.mcmc_info_very_N = 10; % print info every N steps
+settings.mcmc_burnin_iters = round(0.2 * settings.max_mcmc_iters); % burn in iterations
+settings.mcmc_jump_std = priors.T_K_std * .05; % the jump magnitude for updating T_K
+settings.mcmc_initial_T_K = 0; % set to 0 to draw initial guess from distribution
+settings.mcmc_initial_guess_jump_std = priors.T_K_std; % jump magnitude for the initial guess
+settings.mcmc_acceptance_sc = 1; % acceptance threshold = sc * rand()
+
+% set the fixed state variables and single anelastic method
+settings.fixed_SVs.P_GPa = 2;
+settings.fixed_SVs.sig_MPa = 0.1;
+settings.fixed_SVs.phi = 0;
+settings.fixed_SVs.dg_um = 0.01 * 1e6;
+settings.fixed_SVs.f = 1. / 50.;
+settings.fit_a_fixed_TK = 1; % 1 to fixed hidden T_K, 0 to draw from distribution about a hidden mean
+settings.anelastic_method = 'eburgers_psp';
+``` 
+
+### A note on `sample_normal`
  
-for `normrnd`
-on octave
-https://wiki.octave.org/Statistics_package
-from octave terminal 
-```commandline
-pkg install -forge statistics
-pkg load statistics
+The functions in `bayes_0d_funcs` include a drop-in replacement for `normrnd`, called 
+`sample_normal` in order to avoid extra dependencies. It's probably a little slow. You
+could instead replace it with calls to `normrnd` in the following ways:
+
+For octave, install the [Statistics package](https://wiki.octave.org/Statistics_package)
+from octave terminal with 
+```matlab
+> pkg install -forge statistics
+> pkg load statistics
 ```
-matlab will require the statistics and ML toolbox `https://www.mathworks.com/products/statistics.html (normally included in educational licenses).
+
+For MATLAB, you'll need to install the [statistics and ML toolbox](https://www.mathworks.com/products/statistics.html) (normally included in educational licenses).
+
+### additional reading 
+
+The following are nice introductions to writing an mcmc sampler from scratch:
 
 * https://exowanderer.medium.com/metropolis-hastings-mcmc-from-scratch-in-python-c21e53c485b7
 * https://twiecki.io/blog/2015/11/10/mcmc-sampling/
-* 
+ 
 
  

--- a/Projects/bayesian_fitting_0d_mcmc/readme.md
+++ b/Projects/bayesian_fitting_0d_mcmc/readme.md
@@ -1,3 +1,9 @@
+## `bayesian_fiting_0d_mcmc` 
+
+A single paramter bayesian marcov-chain monte carlo (mcmc) simulation with 
+Metropolis-Hastings sampling to invert a spot measurements of shear wave velocity 
+and attenuation for the underyling temperature. 
+ 
 for `normrnd`
 on octave
 https://wiki.octave.org/Statistics_package
@@ -8,5 +14,8 @@ pkg load statistics
 ```
 matlab will require the statistics and ML toolbox `https://www.mathworks.com/products/statistics.html (normally included in educational licenses).
 
-https://exowanderer.medium.com/metropolis-hastings-mcmc-from-scratch-in-python-c21e53c485b7
+* https://exowanderer.medium.com/metropolis-hastings-mcmc-from-scratch-in-python-c21e53c485b7
+* https://twiecki.io/blog/2015/11/10/mcmc-sampling/
+* 
 
+ 

--- a/Projects/bayesian_fitting_0d_mcmc/readme.md
+++ b/Projects/bayesian_fitting_0d_mcmc/readme.md
@@ -1,0 +1,12 @@
+for `normrnd`
+on octave
+https://wiki.octave.org/Statistics_package
+from octave terminal 
+```commandline
+pkg install -forge statistics
+pkg load statistics
+```
+matlab will require the statistics and ML toolbox `https://www.mathworks.com/products/statistics.html (normally included in educational licenses).
+
+https://exowanderer.medium.com/metropolis-hastings-mcmc-from-scratch-in-python-c21e53c485b7
+

--- a/Projects/bayesian_fitting_0d_mcmc/readme.md
+++ b/Projects/bayesian_fitting_0d_mcmc/readme.md
@@ -19,14 +19,17 @@ priors.T_K_std = 200;  % standard deviation of T_K prior distribution
 % mcmc settings:
 % for testing, the following are set to small numbers. they should be increased,
 % which will be obvious when you run this with small numbers...
-settings.max_mcmc_iters = 100; % max iterations for this chain
+settings.mcmc_max_iters = 100; % max iterations for this chain
 settings.mcmc_info_very_N = 10; % print info every N steps
-settings.mcmc_burnin_iters = round(0.2 * settings.max_mcmc_iters); % burn in iterations
+settings.mcmc_burnin_iters = round(0.2 * settings.mcmc_max_iters); % burn in iterations
 settings.mcmc_jump_std = priors.T_K_std * .05; % the jump magnitude for updating T_K
 settings.mcmc_initial_T_K = 0; % set to 0 to draw initial guess from distribution
 settings.mcmc_initial_guess_jump_std = priors.T_K_std; % jump magnitude for the initial guess
 settings.mcmc_acceptance_sc = 1; % acceptance threshold = sc * rand()
 ``` 
+
+**IMPORTANT**: the version of the code sets `mcmc_max_iters` to a **very** small number in order to 
+easily check that the code runs. You'll want to increase this number. How much is up to you :) 
 
 ```matlab
 % set the fixed state variables and single anelastic method
@@ -39,24 +42,32 @@ settings.fit_a_fixed_TK = 1; % 1 to fixed hidden T_K, 0 to draw from distributio
 settings.anelastic_method = 'eburgers_psp';
 ``` 
 
-
-
 ### Explorations 
 
+
 #### Understanding MCMC-MH
+
+The following are a number of ideas for getting a better handle on how different 
+settings affect the inferred result. 
+
 1. what temperature was used to generate the synthetic observations? (check your answer by looking at `bayes_0d_funcs/get_data.m`)
-2. how does the jump magnitude affect convergence?
-3. how does the initial guess affect convergence?
-4. how does the uncertainty of the observations affect convergence? (go edit `bayes_0d_funcs/get_data.m`)
-5. what is the difference in the resulting temperature with different averaging methods:
+2. how does increasing the number of iterations affect convergence?
+3. how does the jump magnitude affect convergence?
+4. how does the initial guess affect convergence? 
+5. how does the uncertainty of the observations affect convergence? (go edit `bayes_0d_funcs/get_data.m`)
+6. what is the difference in the resulting temperature with different averaging methods:
    * taking a single value from the final model
    * taking an average of values after burn-in 
    * averaging single values from multiple runs 
    * averaging values after burn-in across multiple runs 
 
 #### Extending 
-1. How you would include frequency-dependence?
-2. How would add more parameters (like melt fraction or grain size)? 
+
+Here are some coding exercises that would be interesting! 
+
+1. Add frequency-dependence
+2. Add more parameters (like melt fraction or grain size)
+3. Re-write the code as a function and then write a script to run and store results from multiple chains. For more of a challenge, parallelize it.
 
 
 

--- a/Projects/bayesian_fitting_0d_mcmc/readme.md
+++ b/Projects/bayesian_fitting_0d_mcmc/readme.md
@@ -14,7 +14,8 @@ insert notes
 % prior distribution settings
 priors.T_K_mean = 1200 + 273;  % mean of T_K prior distribution
 priors.T_K_std = 200;  % standard deviation of T_K prior distribution
-
+``` 
+```matlab
 % mcmc settings:
 % for testing, the following are set to small numbers. they should be increased,
 % which will be obvious when you run this with small numbers...
@@ -25,7 +26,9 @@ settings.mcmc_jump_std = priors.T_K_std * .05; % the jump magnitude for updating
 settings.mcmc_initial_T_K = 0; % set to 0 to draw initial guess from distribution
 settings.mcmc_initial_guess_jump_std = priors.T_K_std; % jump magnitude for the initial guess
 settings.mcmc_acceptance_sc = 1; % acceptance threshold = sc * rand()
+``` 
 
+```matlab
 % set the fixed state variables and single anelastic method
 settings.fixed_SVs.P_GPa = 2;
 settings.fixed_SVs.sig_MPa = 0.1;
@@ -35,6 +38,27 @@ settings.fixed_SVs.f = 1. / 50.;
 settings.fit_a_fixed_TK = 1; % 1 to fixed hidden T_K, 0 to draw from distribution about a hidden mean
 settings.anelastic_method = 'eburgers_psp';
 ``` 
+
+
+
+### Explorations 
+
+#### Understanding MCMC-MH
+1. what temperature was used to generate the synthetic observations? (check your answer by looking at `bayes_0d_funcs/get_data.m`)
+2. how does the jump magnitude affect convergence?
+3. how does the initial guess affect convergence?
+4. how does the uncertainty of the observations affect convergence? (go edit `bayes_0d_funcs/get_data.m`)
+5. what is the difference in the resulting temperature with different averaging methods:
+   * taking a single value from the final model
+   * taking an average of values after burn-in 
+   * averaging single values from multiple runs 
+   * averaging values after burn-in across multiple runs 
+
+#### Extending 
+1. How you would include frequency-dependence?
+2. How would add more parameters (like melt fraction or grain size)? 
+
+
 
 ### A note on `sample_normal`
  


### PR DESCRIPTION
This PR includes an example of a 0D inversion for just temperature using bayesian mcmc modeling with metropolis-hastings sampling. 

Intended for VBRc workshop tutorial.

Initial push works, needs some clean up.
