### PR TITLE
vbrListMethods bug fix for matlab compatibility

### DIFF
--- a/vbr/support/vbrListMethods.m
+++ b/vbr/support/vbrListMethods.m
@@ -16,9 +16,9 @@ function vbrListMethods(single_prop)
   % vbrListMethods() will print all methods
   % vbrListMethods('viscous') will print only viscous methods 
   %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-    msg = ['DEPRECATION WARNING: vbrListMethods has been renamed to VBR_list_methods',
-       ' vbrListMethods will be removed soon from ',
-       'future version of the VBRc. Use VBR_list_methods to silence ',
+    msg = ['DEPRECATION WARNING: vbrListMethods has been renamed to VBR_list_methods', ...
+       ' vbrListMethods will be removed soon from ', ...
+       'future version of the VBRc. Use VBR_list_methods to silence ', ...
        'this warning.'];
     disp(msg)
     if exist('single_prop', 'var')


### PR DESCRIPTION
Line continuations must include a trailing '...' after the comma, otherwise Matlab interprets them as new rows and throws an error: "Dimensions of arrays being concatenated are not consistent."