### PR TITLE
Rename density funcs, add deprecation warning function

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -1,15 +1,23 @@
 # v1.1.2dev
 
 ## New Features
-* new method: analytica_andrade, an 
+* new method: analytical_andrade, see [documentation](https://vbr-calc.github.io/vbr/vbrmethods/anel/andradeanalytical/) for detials.
 * updates to xfit_premelt: 
   * add direct melt effects from Yamauchi and Takei, 2024. The `xfit_premelt` method will use the updated parameter values when `VBR.in.anelastic.xfit_premelt.include_direct_melt_effect = 1;` (default is 0, a future VBRc version will change the default to 1).
   * change default exponential melt factor (the alpha in exp(-alpha*phi) in the viscosity relationship) from 25 to 30. 
-* add a `VBR_save` function for saving `VBR` structures 
-* add framework for handling temporary files in test suite
+* add a `VBR_save` function for saving `VBR` structures
 * add convenience function, `full_nd`, to create filled arrays
+
+## Bug fixes
+* fix for undefined behavior of pre-melt scaling at Tn == 1.0
+
+## Deprecations
+* `vbrListMethods` has been renamed to `VBR_list_methods`
+* `Density_Thermal_Expansion` has been renamed to `density_thermal_expansion`
+* `Density_Adiabatic_Compression` has been renamed to `density_adiabatic_compression`
+
+## Infrastructure improvements
+* add new function for printing deprecation messages, `print_func_deprecation_warning`
+* add framework for handling temporary files in test suite
 * add a development tag to version structure
 * add weekly test runs
-
-## Bug fix
-* fix for undefined behavior of pre-melt scaling at Tn == 1.0

--- a/vbr/forwardModels/ThermalEvolution_1d/01_functions/MaterialProperties.m
+++ b/vbr/forwardModels/ThermalEvolution_1d/01_functions/MaterialProperties.m
@@ -41,7 +41,7 @@ function [Rho,Cp,Kc,P] = MaterialProperties(Rho_o,Kc_o,Cp_o,T,z,P0,dTdz_ad,PropT
       Kc = Kc_o;
       Cp = Cp_o;
     elseif strcmp(PropType,'P_dep')
-     [Rho,P] = Density_Adiabatic_Compression(Rho_o,z,P0);
+     [Rho,P] = density_adiabatic_compression(Rho_o,z,P0);
       Kc = Kc_o;
       Cp = Cp_o;
     elseif strcmp(PropType,'T_dep')
@@ -51,7 +51,7 @@ function [Rho,Cp,Kc,P] = MaterialProperties(Rho_o,Kc_o,Cp_o,T,z,P0,dTdz_ad,PropT
       Cp = SpecificHeat(T,FracFo);
     elseif strcmp(PropType,'PT_dep')
       Rho = Density_NonAdiabatic_Thermal_Expansion(Rho_o,T,z,dTdz_ad,FracFo);
-     [Rho,P] = Density_Adiabatic_Compression(Rho,z,P0);
+     [Rho,P] = density_adiabatic_compression(Rho,z,P0);
       Kc = ThermalConductivity(Kc_o,T,P);
       Cp = SpecificHeat(T,FracFo);
     elseif strcmp(PropType,'Prescribed_P')
@@ -86,6 +86,6 @@ function [Rho] = Density_NonAdiabatic_Thermal_Expansion(Rho_o,T,Z,dTdz_ad,FracFo
 
     Rho = Rho_o.*ones(size(Z)); % make sure Rho is an array
     Tpot_z = T - dTdz_ad * Z; % the non-adibatic temperature difference
-    Rho = Density_Thermal_Expansion(Rho, Tpot_z, FracFo);
+    Rho = density_thermal_expansion(Rho, Tpot_z, FracFo);
 
 end

--- a/vbr/support/print_func_deprecation_warning.m
+++ b/vbr/support/print_func_deprecation_warning.m
@@ -1,0 +1,28 @@
+function msg = print_func_deprecation_warning(func_old, func_new, dep_type)
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%  msg = print_func_deprecation_warning(func_old, func_new, dep_type)
+%
+%  print a deprecation warning for a function.
+%
+%  Parameters
+%  ----------
+%  func_old
+%    the name of the old function, string
+%  func_new
+%    the name of the new function, string
+%  dep_type
+%    deprecation type, must match one of ['renamed', ]
+%
+%  Returns
+%  str
+%    the deprecation message
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+    msg = "";
+    if strcmp(dep_type, 'renamed')
+        msg = ['\nDEPRECATION WARNING:\n\n', func_old, ' has been renamed to ', ...
+               func_new, ' and ' func_old, ...
+               ' will be removed in a future version of the VBRc. Use ', ...
+               func_new, ' to silence this warning.\n'];
+    end
+    fprintf(msg)
+end

--- a/vbr/support/print_func_deprecation_warning.m
+++ b/vbr/support/print_func_deprecation_warning.m
@@ -1,4 +1,4 @@
-function msg = print_func_deprecation_warning(func_old, func_new, dep_type)
+function msg = print_func_deprecation_warning(func_old, func_new, dep_type, print_it)
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %  msg = print_func_deprecation_warning(func_old, func_new, dep_type)
 %
@@ -12,8 +12,12 @@ function msg = print_func_deprecation_warning(func_old, func_new, dep_type)
 %    the name of the new function, string
 %  dep_type
 %    deprecation type, must match one of ['renamed', ]
+%  print_it
+%    Optional bool, if true (default), will print the message.
 %
 %  Returns
+%  -------
+%
 %  str
 %    the deprecation message
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
@@ -24,5 +28,12 @@ function msg = print_func_deprecation_warning(func_old, func_new, dep_type)
                ' will be removed in a future version of the VBRc. Use ', ...
                func_new, ' to silence this warning.\n'];
     end
-    fprintf(msg)
+
+    if (~exist('print_it', 'var'))
+        print_it = true;
+    end
+
+    if print_it
+        fprintf(msg)
+    end
 end

--- a/vbr/support/vbrListMethods.m
+++ b/vbr/support/vbrListMethods.m
@@ -16,11 +16,7 @@ function vbrListMethods(single_prop)
   % vbrListMethods() will print all methods
   % vbrListMethods('viscous') will print only viscous methods 
   %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-    msg = ['DEPRECATION WARNING: vbrListMethods has been renamed to VBR_list_methods', ...
-       ' vbrListMethods will be removed soon from ', ...
-       'future version of the VBRc. Use VBR_list_methods to silence ', ...
-       'this warning.'];
-    disp(msg)
+    print_func_deprecation_warning('vbrListMethods', 'VBR_list_methods', 'renamed');
     if exist('single_prop', 'var')
         VBR_list_methods(single_prop)
     else

--- a/vbr/testing/test_deprecation_warning.m
+++ b/vbr/testing/test_deprecation_warning.m
@@ -1,0 +1,33 @@
+function TestResult = test_deprecation_warning()
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+% TestResult = test_deprecation_warning()
+%
+% check that the deprecation warning works
+%
+% Parameters
+% ----------
+% none
+%
+% Output
+% ------
+% TestResult  struct with fields:
+%           .passed         True if passed, False otherwise.
+%           .fail_message   Message to display if false
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+    func_old = 'theoldfuncname';
+    func_new = 'thenewfuncname';
+    msg = print_func_deprecation_warning(func_old, func_new, 'renamed', false);
+    TestResult.passed=true;
+    TestResult.fail_message = '';
+    if strfind(msg, func_old) == 0
+        TestResult.passed=false;
+        TestResult.fail_message = ["missing old function from ", msg];
+    end
+
+    if strfind(msg, func_new) == 0
+        TestResult.passed=false;
+        TestResult.fail_message = ["missing new function from ", msg];
+    end
+
+end

--- a/vbr/testing/test_vbrcore_006_density_thermal_funcs.m
+++ b/vbr/testing/test_vbrcore_006_density_thermal_funcs.m
@@ -22,24 +22,24 @@ function TestResult = test_vbrcore_006_density_thermal_funcs()
   rho_o = 3300;
   T_K = 1473;
   FracFo = 1.0;
-  rho = Density_Thermal_Expansion(rho_o, T_K, FracFo);
+  rho = density_thermal_expansion(rho_o, T_K, FracFo);
   dTdP_s = adiabatic_coefficient(T_K, rho, FracFo);
   dTdz_s = adiabatic_gradient(T_K, rho, FracFo);
 
   rho_o = ones(4, 3) * 3300;
-  rho = Density_Thermal_Expansion(rho_o, T_K, FracFo);
+  rho = density_thermal_expansion(rho_o, T_K, FracFo);
   dTdP_s = adiabatic_coefficient(T_K, rho, FracFo);
   dTdz_s = adiabatic_gradient(T_K, rho, FracFo);
 
   FracFo = ones(4, 3) - 0.2;
-  rho = Density_Thermal_Expansion(rho_o, T_K, FracFo);
+  rho = density_thermal_expansion(rho_o, T_K, FracFo);
   dTdP_s = adiabatic_coefficient(T_K, rho, FracFo);
   dTdz_s = adiabatic_gradient(T_K, rho, FracFo);
 
   rho_o = 3300;
   T_K = linspace(1000, 1400, 4) + 273;
   FracFo = 1.0;
-  rho = Density_Thermal_Expansion(rho_o, T_K, FracFo);
+  rho = density_thermal_expansion(rho_o, T_K, FracFo);
   dTdP_s = adiabatic_coefficient(T_K, rho, FracFo);
   dTdz_s = adiabatic_gradient(T_K, rho, FracFo);
 

--- a/vbr/vbrCore/functions/density/Density_Adiabatic_Compression.m
+++ b/vbr/vbrCore/functions/density/Density_Adiabatic_Compression.m
@@ -19,20 +19,8 @@ function [Rho,P] = Density_Adiabatic_Compression(Rho_o,Z,P0)
     %    P   : pressure profile in Pa
     % see page ~190 in 1st edition, 185 in 2nd edition.                 %
     %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-    Rho = Rho_o.*ones(size(Z)); % make sure Rho is an array
-
-    % integrate the reference density profile
-    RhoGZ = cumtrapz(Z,Rho*9.8); % [Pa]
-
-    % adiabatic compressibility (values from Turcotte and Schubert)
-    Beta_Surf = 8.7*1e-12; % at surface [Pa^-1]
-    Beta_CMB = 1.6*1e-12; % at CMB [Pa^-1]
-    Beta_wt = 1; % choose a weighting (1 = use surface Beta)
-    Beta = Beta_wt*Beta_Surf + (1-Beta_wt) * Beta_CMB; % use this value
-
-    % calculate pressure gradient
-    P = -1/Beta * log(1 - Beta * RhoGZ) + P0; % pressure [Pa]
-
-    % calculate Rho(P)
-    Rho = Rho.*exp(Beta * (P-P0));
+    print_func_deprecation_warning('Density_Adiabatic_Compression', ...
+                                   'density_adiabatic_compression', ...
+                                   'renamed');
+    [Rho, P] = density_adiabatic_compression(Rho_o, Z, P0);
 end

--- a/vbr/vbrCore/functions/density/density_adiabatic_compression.m
+++ b/vbr/vbrCore/functions/density/density_adiabatic_compression.m
@@ -1,0 +1,38 @@
+function [Rho,P] = density_adiabatic_compression(Rho_o,Z,P0)
+    %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+    % Adiabatic Compression along a profile following Turcotte and Schubert
+    % should be ok for upper mantle, shallower than the 410 km phase change.
+    %
+    % Parameters
+    % ----------
+    % Rho_o
+    %     reference density in kg/m^3
+    % Z
+    %     depth in m
+    % P0
+    %     reference pressure in Pa
+    %
+    % Output
+    % -------
+    % [Rho, P]
+    %    Rho : adiabatic-corrected density in kg/m^3
+    %    P   : pressure profile in Pa
+    % see page ~190 in 1st edition, 185 in 2nd edition.                 %
+    %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+    Rho = Rho_o.*ones(size(Z)); % make sure Rho is an array
+
+    % integrate the reference density profile
+    RhoGZ = cumtrapz(Z,Rho*9.8); % [Pa]
+
+    % adiabatic compressibility (values from Turcotte and Schubert)
+    Beta_Surf = 8.7*1e-12; % at surface [Pa^-1]
+    Beta_CMB = 1.6*1e-12; % at CMB [Pa^-1]
+    Beta_wt = 1; % choose a weighting (1 = use surface Beta)
+    Beta = Beta_wt*Beta_Surf + (1-Beta_wt) * Beta_CMB; % use this value
+
+    % calculate pressure gradient
+    P = -1/Beta * log(1 - Beta * RhoGZ) + P0; % pressure [Pa]
+
+    % calculate Rho(P)
+    Rho = Rho.*exp(Beta * (P-P0));
+end

--- a/vbr/vbrCore/functions/density/density_thermal_expansion.m
+++ b/vbr/vbrCore/functions/density/density_thermal_expansion.m
@@ -1,4 +1,4 @@
-function [Rho] = Density_Thermal_Expansion(Rho, T_K, FracFo)
+function [Rho] = density_thermal_expansion(Rho, T_K, FracFo)
     %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
     % Corrects density for thermal expansion at fixed pressure
     %
@@ -11,13 +11,12 @@ function [Rho] = Density_Thermal_Expansion(Rho, T_K, FracFo)
     % FracFo : scalar or array
     %     volume fraction of Forsterite
     %
-    % Output 
+    % Output
     % -------
     % Rho : scalar or array
     %     density in same units as input density
     %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-    print_func_deprecation_warning('Density_Thermal_Expansion', ...
-                                   'density_thermal_expansion', 'renamed');
+
     al_int = thermal_expansion_coefficient(T_K, FracFo);
     Rho = Rho .* exp(-al_int);
 


### PR DESCRIPTION
* renames some of the density functions Closes #110 
* adds a new function for printing deprecation warnings, `print_func_deprecation_warning`