### PR TITLE
Linearized Backstress Model

### DIFF
--- a/Projects/vbr_core_examples/CB_017_backstress_model.m
+++ b/Projects/vbr_core_examples/CB_017_backstress_model.m
@@ -1,0 +1,19 @@
+%% put VBR in the path %%
+clear
+path_to_top_level_vbr='../../';
+addpath(path_to_top_level_vbr)
+vbr_init
+
+VBR.in.viscous.methods_list = {'backstress_linear';};
+VBR.in.anelastic.methods_list = {'backstress_linear'};
+% set state variables
+VBR.in.SV.T_K = linspace(1000, 1400, 5) + 273; 
+VBR.in.SV.sig_dc_MPa = [3., 3., 3., 3., 3];
+VBR.in.SV.dg_um = [1e4, 1e4, 1e4, 1e4, 1e4]; 
+
+VBR.in.SV.f = [0.001, 0.01]; 
+
+VBR = VBR_spine(VBR); 
+
+disp(VBR.out.viscous.backstress_linear.eta_total)
+disp(VBR.out.anelastic.backstress_linear.Qinv)

--- a/vbr/vbrCore/functions/Q_backstress_linear.m
+++ b/vbr/vbrCore/functions/Q_backstress_linear.m
@@ -1,0 +1,89 @@
+function [VBR] = Q_backstress_linear(VBR)
+
+    params = VBR.in.viscous.backstress_linear; 
+    if strcmp(params.G_method, 'fixed') 
+        G_GPa = params.G_UR; 
+        M_GPa = params.M; 
+    else 
+        % hardening modulus is a factor of shear modulus 
+        % see Beithaupt et al. 
+        G_GPa  = VBR.in.elastic.anharmonic.Gu; 
+        M_GPa = params.M_G_factor * G_GPa; 
+    end     
+
+    omega = 2 * pi * VBR.in.SV.f ; 
+
+    if isfield(VBR.out.viscous, 'backstress_linear')
+        eta1 = VBR.out.viscous.backstress_linear.eta_total; 
+    else 
+        eta1 = visc_calc_xfit_premelt(VBR); 
+    end 
+
+
+    d_nm = VBR.in.SV.dg_um / 1e3; 
+    
+    % allocation of new matrixes
+    n_freq = numel(omega);
+    sz = size(VBR.in.SV.T_K);    
+    n_th = numel(VBR.in.SV.T_K); % total elements    
+    J1 = proc_add_freq_indeces(zeros(sz),n_freq);
+    J2 = proc_add_freq_indeces(zeros(sz),n_freq);    
+    M = proc_add_freq_indeces(zeros(sz),n_freq);    
+    Qinv = proc_add_freq_indeces(zeros(sz),n_freq);
+
+    % initial calulations     
+    sig_dc_MPa = VBR.in.SV.sig_dc_MPa; 
+    sig_p_MPa = params.sig_p_sig_dc_factor * sig_dc_MPa; 
+
+    sig_d_MPa = params.Beta .* G_GPa .* params.burgers_vector_nm ./ d_nm; 
+
+    E_R = M_GPa .* (sig_p_MPa + sig_d_MPa) ./ sig_p_MPa * 1e9; 
+    E_U = G_GPa * 1e9; 
+    
+    if strcmp(params.G_method, 'fixed')         
+        E_U_i = G_GPa;
+    end 
+
+    % the main loop over state variables
+
+    for i_sv = 1:n_th
+
+        eta_i = eta1(i_sv);
+        E_R_i = E_R(i_sv); 
+        if strcmp(params.G_method, 'fixed') == 0            
+            E_U_i = E_U(i_sv);
+        end 
+
+        for iw = 1:n_freq
+            i_glob = i_sv + (iw - 1) * n_th; % the linear index of the arrays with a frequency index
+            E_star_inv = 1./(E_R_i + eta_i .* omega(iw) * i) + 1 / E_U_i; 
+            E_star_i = 1 ./ E_star_inv; 
+            J1_i(i_glob) = real(E_star_i); 
+            J2_i(i_glob) = imag(E_star_i); 
+            M(i_glob) = norm(E_star_i); 
+            denom = E_R_i.^2 + E_R_i.*E_U_i + eta_i*eta_i*omega(iw)*omega(iw);
+            Qinv(i_glob) = eta_i * E_U_i * omega(iw) ./ (denom);             
+        end 
+    end 
+    
+    % put it all int he output structure
+    out_s = struct();    
+    out_s.Qinv = Qinv; 
+    out_s.J1 = J1; 
+    out_s.J2 = J2;
+    out_s.M = M; 
+
+    if isfield(VBR.in.SV, 'rho')
+        out_s.V = sqrt(1./(out_s.J1) * VBR.in.SV.rho);        
+        out_s.Vave = Q_aveVoverf(out_s.V, VBR.in.SV.f);  
+    end 
+
+    out_s.units = Q_method_units(); 
+    VBR.out.anelastic.backstress_linear = out_s; 
+
+
+
+
+    
+
+end 

--- a/vbr/vbrCore/functions/visc_calc_backstress_linear.m
+++ b/vbr/vbrCore/functions/visc_calc_backstress_linear.m
@@ -1,0 +1,62 @@
+function [VBR] = visc_calc_backstress_linear(VBR)
+
+    params = VBR.in.viscous.backstress_linear; 
+    if strcmp(params.G_method, 'fixed') 
+        G_GPa = params.G_UR;         
+    else         
+        G_GPa  = VBR.in.elastic.anharmonic.Gu;         
+    end 
+    
+
+    
+    Aprime_T = backstress_Aprime(G_GPa, VBR); 
+    % Aprime units = (units(taylor_constant_alpha) * GPa * m) ^ -2
+    sig_ref_T_GPa = backstress_sig_ref_GPa(VBR);
+
+    sig_p_GPa = params.sig_p_sig_dc_factor * VBR.in.SV.sig_dc_MPa * 1e9; 
+    
+    eta_1 = sig_ref_T_GPa ./ (Aprime_T .* sig_p_GPa.^2);
+    eta_1 = eta_1 * 1e9; 
+
+    VBR.out.viscous.backstress_linear.eta_total = eta_1; 
+    
+    
+end 
+
+
+function A_prime_T = backstress_Aprime(G_GPa, VBR)
+    % units will be (units(taylor_constant_alpha) * GPa * m) ^ -2
+
+
+    % parameters for convenience
+    params = VBR.in.viscous.backstress_linear;     
+    alpha = params.taylor_constant_alpha; 
+    bvec = params.burgers_vector_nm * 1e-9;
+    Q = params.Q_J_per_mol; 
+    V = params.V; 
+    R = 8.31446261815324; % J/mol/K
+
+    % state variables 
+    if isfield(VBR.in.SV, 'P_GPa')
+        P_Pa = 1e9.*(VBR.in.SV.P_GPa) ; % [GPa] to [Pa]
+    else 
+        P_Pa = 0.0; 
+    end 
+    T_K = VBR.in.SV.T_K; 
+
+    % the calculation
+    factor = 1./((alpha * G_GPa * bvec).^2);         
+    A_prime_T = factor .* exp(-((Q+P_Pa*V )./ (R * T_K)));     
+end 
+
+function sig_ref_T_GPa = backstress_sig_ref_GPa(VBR)
+
+    % parameters for convenience
+    params = VBR.in.viscous.backstress_linear;             
+    R = 8.31446261815324; % J/mol/K
+    BigSigma = params.pierls_barrier_GPa; 
+    dF = params.Q_J_per_mol; 
+    T_K = VBR.in.SV.T_K;     
+    
+    sig_ref_T_GPa = BigSigma .* R .* T_K ./ dF; 
+end 

--- a/vbr/vbrCore/params/Params_Anelastic.m
+++ b/vbr/vbrCore/params/Params_Anelastic.m
@@ -19,7 +19,7 @@ function params = Params_Anelastic(method,GlobalParams)
 
   % available anelastic methods
   params.possible_methods={'eburgers_psp'; 'andrade_psp'; 'xfit_mxw'; 'xfit_premelt'; ...
-                           'andrade_analytical';};
+                           'andrade_analytical'; 'backstress_linear';};
 
   if strcmp(method,'eburgers_psp')
     % extended burgers parameters
@@ -151,6 +151,28 @@ function params = Params_Anelastic(method,GlobalParams)
       params.viscosity_method_mechanism = 'diff'; % one of the viscous deformation mechanism structure fields
       params.eta_ss = 1e23; % only used if params.viscosity_method == 'fixed'
   end
+
+
+  if strcmp(method, 'backstress_linear')
+    params.func_name='Q_backstress_linear'; % the name of the matlab function
+    params.citations={'Hein et al., 2025, ESS Open Archive (Submitted to JGR Solid Earth ), https://doi.org/10.22541/essoar.174326672.28941810/v1'};
+    params.description='Linearized backstress model.';
+    
+    params.sig_p_sig_dc_factor = 0.8; % see supplement figure S12    
+    params.burgers_vector_nm = 5; % burgers vector in micrometers
+    params.Beta = 2; % geometric constant
+    
+    params.G_UR = 65; % GPa    
+    params.G_method_options = {'fixed'; 'calculated'};
+    params.G_method = {'fixed'}; 
+
+    params.M = 135; % hardening modulus GPa
+    params.M_G_factor = params.M / params.G_UR; % ratio of M to G    
+
+    params.SV_required = {'T_K'; 'sig_dc_MPa' ; 'dg_um'};
+    params.SV_optional = {'P_Pa';};
+  end 
+
   % set steady-state melt dependence for diff. creep (i.e., exp(-alpha * phi))
   HK2003 = Params_Viscous('HK2003'); % viscous parameters
   params.melt_alpha = HK2003.diff.alf ;

--- a/vbr/vbrCore/params/Params_Viscous.m
+++ b/vbr/vbrCore/params/Params_Viscous.m
@@ -16,7 +16,7 @@ function params = Params_Viscous(method,GlobalParams)
   % ------
   % params    the parameter structure for the viscous method
   %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-  params.possible_methods={'HK2003';'HZK2011';'xfit_premelt'};
+  params.possible_methods={'HK2003';'HZK2011';'xfit_premelt'; 'backstress_linear'};
 
   % pull in the small melt effect parameter values
   if ~exist('GlobalParams')
@@ -69,6 +69,34 @@ function params = Params_Viscous(method,GlobalParams)
     % Priestly & McKenzie EPSL 2013 and dg_um = dg_um_r. This assumes that
     % the grain size is at the mean grain size of the upper mantle, which
     % Priestly & McKenzie calculate as 4 mm.
+  elseif strcmp(method,'backstress_linear')
+    % 
+    params.func_name='visc_calc_backstress_linear'; % the name of the matlab function
+    params.citations={'Hein et al., 2025, ESS Open Archive (Submitted to JGR Solid Earth ), https://doi.org/10.22541/essoar.174326672.28941810/v1'};
+    params.description='Linear viscosity for dislocation glide';
+    
+
+    params.V = 0.0; 
+    params.Q_J_per_mol = 450 *1e3; % activation energy J/mol, DeltaF in text
+    
+    params.pierls_barrier_GPa = 3.1; % symbol in text is capital Sigma
+    params.sig_p_sig_dc_factor = 0.8; % see supplement figure S12
+    params.taylor_constant_alpha = taylor_constant = 2.46; % see Breithaupt appendix
+    params.burgers_vector_nm = 5; % burgers vector in micrometers
+    params.Beta = 2; % geometric constant
+    
+    params.G_UR = 65; % GPa    
+    params.G_method_options = {'fixed'; 'calculated'};
+    params.G_method = {'fixed'}; 
+
+    params.M = 135; % hardening modulus GPa
+    params.M_G_factor = params.M / params.G_UR; % ratio of M to G    
+
+    params.SV_required = {'T_K'; 'sig_dc_MPa' };
+    params.SV_optional = {'P_Pa';};
+    
+
+    
   end
 
 


### PR DESCRIPTION
This is an implementation of the linearized backstress model from Hein et al 2025 (https://doi.org/10.22541/essoar.174326672.28941810/v1 ). 

Introduces a new state variable, the bias stress (`sig_dc_MPa`), but otherwise fits the VBRc framework just fine. 